### PR TITLE
Updating the header and lib paths for MacOSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ LDFLAGS    = -lftd2xx
 # Platform-specific rules
 ifeq ($(shell uname -s),Darwin)
   # Mac OS X
-  CFLAGS   = -fast -fomit-frame-pointer -m32 -I/usr/local/include/ -L/usr/local/lib/ 
+  CFLAGS   = -fast -fomit-frame-pointer -m32 -I/usr/local/include/
+  LDFlags += -L/usr/local/lib/
   SUDO     = sudo
 endif
 ifeq ($(shell uname -s),Linux)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LDFLAGS    = -lftd2xx
 # Platform-specific rules
 ifeq ($(shell uname -s),Darwin)
   # Mac OS X
-  CFLAGS   = -fast -fomit-frame-pointer -m32
+  CFLAGS   = -fast -fomit-frame-pointer -m32 -I/usr/local/include/ -L/usr/local/lib/ 
   SUDO     = sudo
 endif
 ifeq ($(shell uname -s),Linux)


### PR DESCRIPTION
The current FTDI instructions http://www.ftdichip.com/Drivers/D2XX.htm have you install into /usr/local/include and /usr/local/lib which are not checked by gcc.
